### PR TITLE
Fix README image links

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ Whenever you hover on a rem, a faint highlight background color appears on that 
 
 Light Theme                | Dark Theme  
 :-------------------------:|:-------------------------:
-![](https://github.com/mzguntalan/ease-of-sight/blob/main/imgs/light/hover_on_description.png)  |  ![](https://github.com/mzguntalan/ease-of-sight/blob/main/imgs/dark/hover_on_description.png)
-![](https://github.com/mzguntalan/ease-of-sight/blob/main/imgs/light/hover_on_fox.png)  |  ![](https://github.com/mzguntalan/ease-of-sight/blob/main/imgs/dark/hover_on_fox.png)
+![](https://raw.githubusercontent.com/mzguntalan/ease-of-sight/main/imgs/light/hover_on_description.png)  |  ![](https://raw.githubusercontent.com/mzguntalan/ease-of-sight/main/imgs/dark/hover_on_description.png)
+![](https://raw.githubusercontent.com/mzguntalan/ease-of-sight/main/imgs/light/hover_on_fox.png)  |  ![](https://raw.githubusercontent.com/mzguntalan/ease-of-sight/main/imgs/dark/hover_on_fox.png)
 
 ## Focus on your Editing
 Whenever you edit a rem, a highlight background color appears and faint highlight background color over the adjacent rems of the same level.
 
 Light Theme                | Dark Theme  
 :-------------------------:|:-------------------------:
-![](https://github.com/mzguntalan/ease-of-sight/blob/main/imgs/light/edit_on_fox_color.png)  |  ![](https://github.com/mzguntalan/ease-of-sight/blob/main/imgs/dark/edit_on_fox_color.png)
-![](https://github.com/mzguntalan/ease-of-sight/blob/main/imgs/light/edit_on_person.png)  |  ![](https://github.com/mzguntalan/ease-of-sight/blob/main/imgs/dark/edit_on_person.png)
+![](https://raw.githubusercontent.com/mzguntalan/ease-of-sight/main/imgs/light/edit_on_fox_color.png)  |  ![](https://raw.githubusercontent.com/mzguntalan/ease-of-sight/main/imgs/dark/edit_on_fox_color.png)
+![](https://raw.githubusercontent.com/mzguntalan/ease-of-sight/main/imgs/light/edit_on_person.png)  |  ![](https://raw.githubusercontent.com/mzguntalan/ease-of-sight/main/imgs/dark/edit_on_person.png)
 


### PR DESCRIPTION
Replacing `https://github.com/...` links with `https://raw.githubusercontent.com/...` to make the images display correctly on the plugin marketplace.